### PR TITLE
Add support for ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Seal
 
 This role performs sealing steps for following operating systems:
 
-* RedHat / CentOS  ([oVirt site](http://www.ovirt.org/documentation/how-to/virtual-machines/sealing-linux-vm/).)
+* RedHat / CentOS  ([oVirt site](http://www.ovirt.org/documentation/how-to/virtual-machines/sealing-linux-vm/))
 * Ubuntu / Debian
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 Seal
 ====
 
-Performs sealing of Red Hat Enterprise Linux machine described at
-[oVirt site](http://www.ovirt.org/documentation/how-to/virtual-machines/sealing-linux-vm/).
+This role performs sealing steps for following operating systems:
+
+* RedHat / CentOS  ([oVirt site](http://www.ovirt.org/documentation/how-to/virtual-machines/sealing-linux-vm/).)
+* Ubuntu / Debian
 
 Requirements
 ------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: Katerina Koukiou
-  description: Role to seal RHEL machine
+  description: Role to seal Linux machine
   company: RedHat
   license: GPLv3
   min_ansible_version: 2.2
@@ -9,6 +9,12 @@ galaxy_info:
     versions:
     - 6
     - 7
+  - name: Ubuntu
+    versions:
+    - all
+  - name: Debian
+    versions:
+    - all
   galaxy_tags:
   - seal
   - sealing

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,9 +35,9 @@
     dest: "{{ seal_hostname_file_path }}"
     content: 'localhost.localdomain'
     unsafe_writes: "{{ seal_run_containerized }}"
-  when:
-    - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version|int > 6
+  when: (ansible_os_family == "RedHat" and
+         ansible_distribution_major_version|int > 6) or
+         ansible_os_family == "Debian"
   tags:
     - reset_hostname
 
@@ -48,21 +48,30 @@
   with_fileglob:
     - /etc/udev/rules.d/70-*
 
-- name: remove HWADDR from ifcfg-*
+- name: remove HWADDR from ifcfg-* on RHEL/Centos
   lineinfile:
     dest: "{{ item }}"  # 'path' is new in 2.3
     state: absent
     regexp: "^HWADDR=.*"
   with_fileglob:
     - /etc/sysconfig/network-scripts/ifcfg-*
+  when: ansible_os_family == "RedHat"
 
-- name: remove UUID from ifcfg-*
+- name: remove UUID from ifcfg-* on RHEL/Centos
   lineinfile:
     dest: "{{ item }}"  # 'path' is new in 2.3
     state: absent
     regexp: "^UUID=.*"
   with_fileglob:
     - /etc/sysconfig/network-scripts/ifcfg-*
+  when: ansible_os_family == "RedHat"
+
+- name: remove hwaddr information from network interfaces on Ubuntu/Debian
+  lineinfile:
+    dest: "/etc/network/interfaces"  # 'path' is new in 2.3
+    state: absent
+    regexp: "^[ \t]*hwaddress.*"
+  when: ansible_os_family == 'Debian'
 
 - name: remove log files and dir from /var/log
   file:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -12,11 +12,12 @@
         image: "registry.access.redhat.com/rhel6:latest"
       - name: seal_rhel7
         image: "registry.access.redhat.com/rhel:latest"
-# Role doesn't support ubuntu
-#      - name: seal_ubuntu12
-#        image: "chrismeyers/ubuntu12.04"
-#      - name: seal_ubuntu14
-#        image: "ubuntu-upstart:14.04"
+      - name: seal_ubuntu12
+        image: "chrismeyers/ubuntu12.04"
+      - name: seal_ubuntu14
+        image: "nimmis/ubuntu:14.04"
+      - name: seal_ubuntu16
+        image: "nimmis/ubuntu:16.04"
   roles:
     - role: provision_docker
       provision_docker_inventory: "{{ inventory }}"


### PR DESCRIPTION
This PR adds support for Ubuntu machines and also add tests for that.

I wanted to add Debian support in tests as well but faced the following problems:
By default recent Debian versions don't have python-minimal package installed which brings the '/usr/bin/python' symbolic link, and just have the versioned symbolic link (/usr/bin/python2, /usr/bin/python3).  As a result ansible cannot find the python interpreter.
One solution would be to pass the parameter ansible_python_interpreter=/usr/bin/python3, to explicitly specify the interpreter path. This only works when OS is shipped with python2 however.

With python3 we have more issues with ansible, like: 
*ImportError: No module named 'urlparse* when using python3.
(Faced this in Debian 8 which has python 3.4. installed by default - Ansible needs 3.5) 

PS: Same problem with missing /usr/bin/python symbilic link I faced in ubuntu containers as well, but managed to overcome it finding images with the appropriate packages installed.