### PR TITLE
remove content from /etc/machine-id

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,6 +82,9 @@
   tags:
     - delete_logs
 
+- name: remove content from /etc/machine-id file
+  shell: "> /etc/machine-id"
+
 - name: Poweroff host
   shell: "shutdown -t sec 5"
   async: 1


### PR DESCRIPTION
In case we create more than one VM from a template
that will be added as hypervisors to same RHV engine, we will only
succeed to add one of the hypervisors becuase the other will fail due to
that both have same machine-id.

This change should remove content from /etc/machine-id and we won't bump
into this issue.